### PR TITLE
added sample name to directory check line 132

### DIFF
--- a/dt.py
+++ b/dt.py
@@ -129,7 +129,7 @@ with open(args.f, 'r') as infiletsv, open('Samplemap.csv', 'w') as sf:
         if not (args.ub or args.ab):
 
             if not os.path.isdir(line['Full Path']):
-                print('{} directory not found.'.format(line['Full Path']))
+                print('Sample: {}, {} directory not found.'.format(line['Sample Full Name'], line['Full Path']))
                 continue
 
             paths(line['Full Path'], dt_dir)


### PR DESCRIPTION
Checks to see if dir exists, returns dir in print statement to user, added sample name in addition as there was a case where the directory field was empty.  Sample name would help correlate missing directory field. 